### PR TITLE
Fix PDFLayoutTextStripper space check

### DIFF
--- a/project/backend/src/main/java/dev/lueem/extract/PDFLayoutTextStripper.java
+++ b/project/backend/src/main/java/dev/lueem/extract/PDFLayoutTextStripper.java
@@ -79,8 +79,14 @@ class TextLine {
         }
     }
 
+    /**
+     * Checks if the character at the given index in the line is a space.
+     *
+     * @param index position within the line
+     * @return {@code true} if the character is a space, otherwise {@code false}
+     */
     private boolean isSpaceCharacterAtIndex(int index) {
-        return this.line.charAt(index) != SPACE_CHARACTER;
+        return this.line.charAt(index) == SPACE_CHARACTER;
     }
 
     private boolean isNewIndexGreaterThanLastIndex(int index) {


### PR DESCRIPTION
## Summary
- correct `isSpaceCharacterAtIndex` logic and document method

## Testing
- `mvn -q -f project/backend/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fff991f348325896d7313eb75d0e3